### PR TITLE
Ajout d'une étape

### DIFF
--- a/Module02_Git_Les basesetBranches/Module02_Git_Les basesetBranches_Exercices.md
+++ b/Module02_Git_Les basesetBranches/Module02_Git_Les basesetBranches_Exercices.md
@@ -52,6 +52,7 @@ FichierIgnore.md
   - Essayez de déduire ce que fait chacune de ces commandes
   - À l'aide de ces commandes, utilisez simplement les commandes les plus pertinentes (pas besoin de tout copier-coller):
     - Ajout du dépôt distant (`git remote add origin <url>`)
+    - Paramétrer la branche upstream pour les push (`git push --set-upstream origin master`)
     - Envoi des modifications sur le dépôt distant (`git push`)
 - Validez de nouveau les changements sur GitHub
 


### PR DESCRIPTION
Nom par défaut de la branche "master".
Si la branche est renommée (de master à main, par exemple) cette étape n'est pas nécessaire.